### PR TITLE
Allow using pc-nrfjprog-js directly

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,7 +40,7 @@
         "import/no-unresolved": [
             "error",
             {
-                "ignore": [ "nrfconnect/.*", "pc-ble-driver-js", "serialport", "electron" ]
+                "ignore": [ "nrfconnect/.*", "pc-ble-driver-js", "pc-nrfjprog-js", "serialport", "electron" ]
             }
         ],
         "import/extensions": ["off"],

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\""
   },
   "devDependencies": {
-    "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git"
+    "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#v1.0.0"
   },
   "dependencies": {},
   "jest": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,10 +12,10 @@ function createExternals() {
         'react-dom',
         'react-redux',
         'pc-ble-driver-js',
+        'pc-nrfjprog-js',
         'serialport',
         'electron',
         'nrfconnect/core',
-        'nrfconnect/programming',
     ];
 
     // Libs provided by the app at runtime

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ function createExternals() {
 }
 
 module.exports = {
-    devtool: isProd ? 'hidden-source-map' : 'inline-eval-cheap-source-map',
+    devtool: isProd ? 'hidden-source-map' : 'cheap-module-source-map',
     entry: './index.jsx',
     output: {
         path: path.join(__dirname, 'dist'),


### PR DESCRIPTION
Allow using pc-nrfjprog-js directly. Also align source map with our other projects, plus lock down the pc-nrfconnect-devdep dependency to v1.0.0.