### PR TITLE
Replace links to old wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 ## Development
 
-See the [app development](https://github.com/NordicSemiconductor/pc-nrfconnect-core/wiki) pages for details on how to develop apps for the nRF Connect for Desktop framework.
+See the [app development](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/) pages for details on how to develop apps for the nRF Connect for Desktop framework.
 
 ## Feedback
 
@@ -60,7 +60,7 @@ Please report issues on the [DevZone](https://devzone.nordicsemi.com) portal.
 
 ## Contributing
 
-See the [Contributing](https://github.com/NordicSemiconductor/pc-nrfconnect-core/wiki/Contributing) file for details.
+See the [infos on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing) for details.
 
 ## License
 

--- a/index.jsx
+++ b/index.jsx
@@ -53,7 +53,7 @@ import './resources/css/index.less';
 // for customizing the app should be removed.
 //
 // The API for apps is also documented with additional examples on:
-// https://github.com/NordicSemiconductor/pc-nrfconnect-core/wiki/API-reference
+// https://nordicsemiconductor.github.io/pc-nrfconnect-docs/api_reference
 
 
 // App configuration


### PR DESCRIPTION
Similar to NordicSemiconductor/pc-nrfconnect-gettingstarted#7:

Because we are moving from https://github.com/NordicSemiconductor/pc-nrfconnect-core/wiki to https://nordicsemiconductor.github.io/pc-nrfconnect-docs/.