### PR TITLE
Fix: Incomplete switch to esbuild

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run check && npm t

--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,5 +1,0 @@
-{
-    "hooks": {
-        "pre-push": "bash node_modules/pc-nrfconnect-shared/scripts/pre-push.sh"
-    }
-}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "check:lint": "eslint --color .",
         "check:types": "check-for-typescript tsc --noEmit --pretty",
         "check:license": "nrfconnect-license check",
-        "nordic-publish": "nordic-publish"
+        "nordic-publish": "node ./dist/nordic-publish.js"
     },
     "devDependencies": {
         "pc-nrfconnect-shared": "https://github.com/NordicSemiconductor/pc-nrfconnect-shared#v6.12.1"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "check:lint": "eslint --color .",
         "check:types": "check-for-typescript tsc --noEmit --pretty",
         "check:license": "nrfconnect-license check",
-        "nordic-publish": "node ./dist/nordic-publish.js"
+        "nordic-publish": "node ./dist/nordic-publish.js",
+        "prepare": "husky install"
     },
     "devDependencies": {
         "pc-nrfconnect-shared": "https://github.com/NordicSemiconductor/pc-nrfconnect-shared#v6.12.1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "author": "Nordic Semiconductor ASA",
     "license": "SEE LICENSE IN LICENSE",
     "engines": {
-        "nrfconnect": "^3.11.1"
+        "nrfconnect": ">=4.0.0"
     },
     "main": "dist/bundle.js",
     "files": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,0 @@
-/*
- * Copyright (c) 2022 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
- */
-
-module.exports = require('pc-nrfconnect-shared/config/webpack.config');


### PR DESCRIPTION
The app now requires at least version 4 of nRF Connect for Desktop to run correctly when built with `esbuild`.

The webpack config also isn't needed anymore.

Also corrected the publish script and updated the husky config, according to the “Steps to upgrade when using this package” sections in [`shared`'s `Changelog.md`](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/blob/main/Changelog.md).