### PR TITLE
Use more flexible tsconfig location

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,3 @@
 {
-    "extends": "./node_modules/pc-nrfconnect-shared/config/tsconfig.json"
+    "extends": "pc-nrfconnect-shared/config/tsconfig.json"
 }


### PR DESCRIPTION
The old config only worked if pc-nrfconnect-shared is found top level in the node_modules folder directly in this project. In some cases it is found in other places, e.g. when using npm workspaces. The new config is shorter and uses the npm module resolution mechanism, so the tsconfig will be found in more places.