### PR TITLE
Prepare for using npm workspaces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+module.exports = require('@nordicsemiconductor/pc-nrfconnect-shared/config/eslintrc');

--- a/package.json
+++ b/package.json
@@ -47,8 +47,5 @@
         "@types/react-test-renderer": "18.0.0",
         "@nordicsemiconductor/pc-nrfconnect-shared": "^91.0.0"
     },
-    "eslintConfig": {
-        "extends": "./node_modules/@nordicsemiconductor/pc-nrfconnect-shared/config/eslintrc"
-    },
-    "prettier": "./node_modules/@nordicsemiconductor/pc-nrfconnect-shared/config/prettier.config.js"
+    "prettier": "@nordicsemiconductor/pc-nrfconnect-shared/config/prettier.config.js"
 }


### PR DESCRIPTION
When using npm workspaces, `pc-nrfconnect-shared` may not lie in the direct `node_modules/` folder. This lets the prettier and ESLint config be loaded through the npm module resolution, meaning it can also be found in places where it is placed by npm workspaces, e.g. in a parent folder.