### PR TITLE
Publish docs on prod release

### DIFF
--- a/.github/workflows/docs-bundle.yml
+++ b/.github/workflows/docs-bundle.yml
@@ -1,0 +1,19 @@
+name: 'Docs: Create bundle'
+
+# If this project has docs, set a correct bundle-name below (and also
+# in the other workflows) and uncomment the pull_request trigger.
+
+on:
+    # pull_request:
+    #     types: [synchronize, opened, reopened]
+    #     paths:
+    #         - .github/workflows/docs-bundle.yml
+    #         - doc
+    workflow_dispatch:
+    workflow_call:
+
+jobs:
+    create-doc-bundle:
+        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-bundle.yml@main
+        with:
+            bundle-name: nrf-connect-boilerplate

--- a/.github/workflows/docs-publish-dev.yml
+++ b/.github/workflows/docs-publish-dev.yml
@@ -1,0 +1,21 @@
+name: 'Docs: Publish to dev'
+
+# If this project has docs, set a correct bundle-name below (and also
+# in the other workflows) and uncomment the push trigger.
+
+on:
+    # push:
+    #     branches:
+    #         - main
+    #     paths:
+    #         - doc/
+    #         - .github/workflows/docs-*.yml
+    workflow_dispatch:
+
+jobs:
+    publish-docs-bundle:
+        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
+        with:
+            bundle-name: nrf-connect-boilerplate
+            release-type: dev
+        secrets: inherit

--- a/.github/workflows/docs-publish-prod.yml
+++ b/.github/workflows/docs-publish-prod.yml
@@ -1,0 +1,16 @@
+name: 'Docs: Publish to prod'
+
+# If this project has docs, set a correct bundle-name below (and also
+# in the other workflows).
+
+on:
+    workflow_dispatch:
+    workflow_call:
+
+jobs:
+    publish-docs-bundle:
+        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
+        with:
+            bundle-name: nrf-connect-boilerplate
+            release-type: prod
+        secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,5 @@ jobs:
         with:
             source: ${{ inputs.source }}
             ref: ${{ inputs.ref }}
+            # doc_bundle_name: nrf-connect-boilerplate # If this project has documentation, uncomment this line and set the right bundle name for the docs
         secrets: inherit


### PR DESCRIPTION
For [NCD-1394](https://nordicsemi.atlassian.net/browse/NCD-1394):

Publish docs on releasing to official. 

Also: Add workflows for creating and publishing the docs bundle that can be activated when docs are added.

