### PR TITLE
Bump nrfutil-core to 8.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "nrfconnect": ">=5.2.0"
     },
     "nrfConnectForDesktop": {
-        "nrfutilCore": "8.0.0",
+        "nrfutilCore": "8.1.1",
         "nrfutil": {
             "device": [
                 "2.7.16"


### PR DESCRIPTION
Bump nrfutil-core to 8.1.1. Because https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/issues/1189 showed that it is necessary for some users.